### PR TITLE
Destructive changeset with an antlernative package.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ Just run a [partial deploy](#deploy-partial-metadata) passing the `--destructive
 $ sfdy deploy -u USERNAME -p PASSWORD -s --files='objects/*,!objects/Account*,site*/**/*' --destructive
 ```
 
+You can also run a destructive deploy changeset with a custom destructiveChanges.xml path:
+
+```
+$ sfdy deploy -u USERNAME -p PASSWORD -s --destructive <destructiveChanges.xml path>
+```
+
 > **Warning:** Full destructive deploy is deliberately not supported
 
 > **Warning:** This command deletes the metadata files from Salesforce, but they remain on the filesystem

--- a/src/deploy/index.js
+++ b/src/deploy/index.js
@@ -83,8 +83,8 @@ module.exports = async ({
     return { status: 'Succeeded' }
   }
 
-  if ((specificFilesMode || !destructivePackage) && destructive) {
-    throw Error('Full destructive changeset is too dangerous. You must specify --files, --diff or --destructive-package option')
+  if (!(specificFilesMode || destructivePackage) && destructive) {
+    throw Error('Full destructive changeset is too dangerous. You must specify --files, --diff or a value for the destructive option')
   }
 
   logger.log(chalk.green(`Built package.xml!`))
@@ -107,7 +107,7 @@ module.exports = async ({
     logger.log(chalk.grey(fileList.join('\n')))
     const pkgJson = await getPackageXml({ specificFiles: fileList, sfdcConnector, skipParseGlobPatterns: true })
     zip.addBuffer(Buffer.from(buildXml({ Package: pkgJson }) + '\n', 'utf-8'), 'destructiveChanges.xml')
-    } else if (destructivePackage) {
+    } else if (destructivePackage && typeof destructivePackage === 'string') {
       logger.log(chalk.yellow(`Metadata specified in ${destructivePackage} will be deleted`))
       const pkgJson = await getPackageXml({ specificPackage: destructivePackage, sfdcConnector, skipParseGlobPatterns: true })
       zip.addBuffer(Buffer.from(buildXml({ Package: pkgJson }) + '\n', 'utf-8'), 'destructiveChanges.xml')

--- a/src/deploy/index.js
+++ b/src/deploy/index.js
@@ -19,7 +19,7 @@ module.exports = async ({
   loginOpts,
   checkOnly = false,
   destructive = false,
-  package,
+  destructivePackage,
   basePath,
   logger: _logger,
   diffCfg,
@@ -83,8 +83,8 @@ module.exports = async ({
     return { status: 'Succeeded' }
   }
 
-  if ((specificFilesMode || !package) && destructive) {
-    throw Error('Full destructive changeset is too dangerous. You must specify --files, --diff or --package option')
+  if ((specificFilesMode || !destructivePackage) && destructive) {
+    throw Error('Full destructive changeset is too dangerous. You must specify --files, --diff or --destructive-package option')
   }
 
   logger.log(chalk.green(`Built package.xml!`))
@@ -107,9 +107,9 @@ module.exports = async ({
     logger.log(chalk.grey(fileList.join('\n')))
     const pkgJson = await getPackageXml({ specificFiles: fileList, sfdcConnector, skipParseGlobPatterns: true })
     zip.addBuffer(Buffer.from(buildXml({ Package: pkgJson }) + '\n', 'utf-8'), 'destructiveChanges.xml')
-    } else if (package) {
-      logger.log(chalk.yellow(`Metadata specified in ${package} will be deleted`))
-      const pkgJson = await getPackageXml({ specificPackage: package, sfdcConnector, skipParseGlobPatterns: true })
+    } else if (destructivePackage) {
+      logger.log(chalk.yellow(`Metadata specified in ${destructivePackage} will be deleted`))
+      const pkgJson = await getPackageXml({ specificPackage: destructivePackage, sfdcConnector, skipParseGlobPatterns: true })
       zip.addBuffer(Buffer.from(buildXml({ Package: pkgJson }) + '\n', 'utf-8'), 'destructiveChanges.xml')
     }
   } else {

--- a/src/sfdy-deploy.js
+++ b/src/sfdy-deploy.js
@@ -14,7 +14,7 @@ program
   .option('-d, --diff <branchRange>', 'Delta deploy from branch to branch - example develop..uat')
   .option('-t, --test-report', 'Generate junit test-report.xml')
   .option('--destructive', 'Deploy a destructive changeset')
-  .option('--package <file>', 'Specify a different package.xml name (useful with destructive changeset)')
+  .option('--destructive-package <file>', 'Specify the path for the package.xml of the destructive changeset')
   .option('--validate', 'Simulate a deployment')
   .option('--test-level <testLevel>', 'Override default testLevel')
   .option('--specified-tests <specifiedTests>', 'Comma separated list of tests to execute if testlevel=RunSpecifiedTests')
@@ -37,7 +37,7 @@ deploy({
     serverUrl: program.serverUrl
   },
   destructive: !!program.destructive,
-  package: program.package,
+  destructivePackage: program.destructivePackage,
   checkOnly: !!program.validate,
   preDeployPlugins: config.preDeployPlugins || [],
   renderers: config.renderers || [],

--- a/src/sfdy-deploy.js
+++ b/src/sfdy-deploy.js
@@ -13,8 +13,7 @@ program
   .option('-f, --files <files>', 'Deploy specific files (comma separated)')
   .option('-d, --diff <branchRange>', 'Delta deploy from branch to branch - example develop..uat')
   .option('-t, --test-report', 'Generate junit test-report.xml')
-  .option('--destructive', 'Deploy a destructive changeset')
-  .option('--destructive-package <file>', 'Specify the path for the package.xml of the destructive changeset')
+  .option('--destructive [file]', 'Deploy a destructive changeset - optionally specify the path for the package.xml of the destructive changeset')
   .option('--validate', 'Simulate a deployment')
   .option('--test-level <testLevel>', 'Override default testLevel')
   .option('--specified-tests <specifiedTests>', 'Comma separated list of tests to execute if testlevel=RunSpecifiedTests')
@@ -37,7 +36,7 @@ deploy({
     serverUrl: program.serverUrl
   },
   destructive: !!program.destructive,
-  destructivePackage: program.destructivePackage,
+  destructivePackage: typeof program.destructive === 'string' && program.destructive,
   checkOnly: !!program.validate,
   preDeployPlugins: config.preDeployPlugins || [],
   renderers: config.renderers || [],

--- a/src/utils/package-utils.js
+++ b/src/utils/package-utils.js
@@ -66,7 +66,7 @@ module.exports = {
       }
     }
     if (hasSpecificPackage) {
-      return (await parseXml(fs.readFileSync(`${pathService.getBasePath()}/${opts.specificPackage}`))).Package
+      return (await parseXml(fs.readFileSync(path.resolve(pathService.getBasePath(), opts.specificPackage)))).Package
     } else {
       return (await parseXml(fs.readFileSync(pathService.getPackagePath()))).Package
     }


### PR DESCRIPTION
Hi Michele,
this is a PR to make sfdy work with destructive changesets and a custom package.xml

As an example, you can use it with this command:

```
sfdy deploy -u <user> -p <password> -s --destructive-package ./destructive-changeset/destructiveChanges.xml --destructive
```

As you can see, I'm using both the destructive-package and the destructive options.
With the first one you specify where your custom package is stored (it could also be a custom package to use in other parts of sfdy). With the second one you declare a destructive.

Maybe we should convert the destructive options to a string and not a boolean to unify these two options, but I was asking about your opinion. 