### PR TITLE
Fix removal of enabled field permissions when corresponding object is disabled in profile

### DIFF
--- a/src/plugins/profile-plugins/add-objects-to-profiles.js
+++ b/src/plugins/profile-plugins/add-objects-to-profiles.js
@@ -71,7 +71,7 @@ module.exports = async (context, helpers) => {
       .map(x => Array.isArray(x.object) ? x.object[0] : x.object)
       .value())
     if (fJson.fieldPermissions) {
-      fJson.fieldPermissions = fJson.fieldPermissions.filter(x => !disabledObjects.has(x.field[0].split('.')[0]))
+      fJson.fieldPermissions = fJson.fieldPermissions.filter(x => !disabledObjects.has(x.field[0].split('.')[0]) || x.editable === 'true' || x.readable == 'true')
     }
     context.log(chalk.blue('----> Done'))
   })


### PR DESCRIPTION
Applying standard patch `addDisabledVersionedObjects` disabled versioned objects are added to profiles as per documentation. However, when this option is enabled, field permissions of disabled versioned objects are removed from profiles. This is not documented. Moreover, field permissions may be truthful even if their object permissions aren't. This PR aim to keep these fields permissions in profiles. My suggestion is to remove the filter on field permissions and add it in a separate standard patch.