### PR TITLE
Bug resolution on code coverage log

### DIFF
--- a/src/deploy/result-logger.js
+++ b/src/deploy/result-logger.js
@@ -30,7 +30,7 @@ const printDeployResult = (deployResult) => {
       logger.log(chalk.red('\nCode Coverage Failures:'))
       const errCounter = counterGen()
       _([d.runTestResult.codeCoverageWarnings]).flatten().each(x => {
-        logger.log(chalk.red(`${errCounter()} ${x.name} -- ${x.message}`))
+        logger.log(chalk.red(`${errCounter()} -- ${x.message}`))
       })
     }
   }


### PR DESCRIPTION
name seems empty,

```
[Object: null prototype] {
  id: '01pdY00000001xBQAQ',
  message: 'Average test coverage across all Apex Classes and Triggers is 73%, at least 75% test coverage is required.',
  name: [Object: null prototype] {
    '$': [Object: null prototype] { 'xsi:nil': 'true' }
  },
  namespace: ''
}
```

So I suggest to remove x.name, in order to avoid the following errror:

```
        logger.log(chalk.red(`${errCounter()} ${x.name} -- ${x.message}`))
                                                  ^

TypeError: Cannot convert object to primitive value
```